### PR TITLE
Set upper bound for NaiveNASflux

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 Conda = "1.3.0"
-NaiveNASflux = "1"
+NaiveNASflux = "< 1.5.0"
 ONNX = "0.1"
 PyCall = "1.91.2"
 Setfield = "0.3.4, 0.5, 0.6"


### PR DESCRIPTION
As 1.5.0 will not be compatible due to changes in Flux 0.11