### PR TITLE
Some improvements to input shape validation and inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ onnx("model.onnx", model, inputshapes...)
 # Load model as a CompGraph
 graph = CompGraph("model.onnx")
 ```
-Input shapes can be omitted in which case no size information is recorded. If supplied, one tuple with size as the dimensions of the corresponding input array (including batch dimension) is expected. 
+Input shapes can be omitted in which case an attempt to infer the shapes will be made. If supplied, one tuple with size as the dimensions of the corresponding input array (including batch dimension) is expected. 
 
 Elements of input shape tuples can have one of the following types:
 * `Integer`: The size of the corresponding dimension

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Exporting is done using the `onnx` function which accepts a filename `String` or
 onnx("model.onnx", model, inputshapes...)
 
 # Load model as a CompGraph
-graph = CompGraph("model.onnx")
+graph = CompGraph("model.onnx", inputshapes...)
 ```
 Input shapes can be omitted in which case an attempt to infer the shapes will be made. If supplied, one tuple with size as the dimensions of the corresponding input array (including batch dimension) is expected. 
 
@@ -32,7 +32,7 @@ Elements of input shape tuples can have one of the following types:
 * `Missing`: No shape info will be recorded for this dimension
 * `Symbol` : Use the provided symbol as a variable name in the exported ONNX model
 
-The example below shows some of these options in action.
+Names can be attached to inputs by providing a `Pair` where the first element is the name as a string, for example `"imageinput" => (:W, :H, 3, missing)`. Note that non-integer input sizes will be ignored when loading a model.
 
 More elaborate example with a model defined as a plain Julia function:
 

--- a/src/baseonnx/read.jl
+++ b/src/baseonnx/read.jl
@@ -47,6 +47,7 @@ end
 
 Base.size(vip::ValueInfoProto) = size(vip._type)
 Base.size(tp::TypeProto) = size(tp.tensor_type)
+Base.size(tp::TensorProto) = tp.dims
 Base.size(tp_t::TypeProto_Tensor) = size(tp_t.shape)
 Base.size(tsp::TensorShapeProto) = size.(Tuple(reverse(tsp.dim)))
 Base.size(tsp_d::TensorShapeProto_Dimension) = hasproperty(tsp_d, :dim_value) ? tsp_d.dim_value : missing

--- a/src/deserialize/deserialize.jl
+++ b/src/deserialize/deserialize.jl
@@ -16,17 +16,18 @@ NaiveNASlib.name(vip::ONNX.ValueInfoProto) = vip.name
 NaiveNASlib.name(tp::ONNX.TensorProto) = tp.name
 
 """
-   CompGraph(filename::String)
+   CompGraph(filename::String, insizes...)
 
 Return a [`CompGraph`](@ref) loaded from the given file.
-"""
-NaiveNASlib.CompGraph(filename::String, vfun = create_vertex_default) = open(io -> CompGraph(io, vfun), filename)
-NaiveNASlib.CompGraph(io::IO, vfun = create_vertex_default) = CompGraph(extract(io), vfun)
-NaiveNASlib.CompGraph(m::ONNX.ModelProto, vfun = create_vertex_default) = CompGraph(m.graph, vfun)
 
-function NaiveNASlib.CompGraph(g::ONNX.GraphProto, vfun = create_vertex_default)
-   gb = CompGraphBuilder(g)
-   outputs::Vector{AbstractVertex} = vertex.(gb, node.(name.(g.output), gb), vfun)
+Argument insizes and be either size tuples or name => tuple pairs indicating the size for each model input.
+"""
+NaiveNASlib.CompGraph(filename::String, insizes...; vfun = create_vertex_default) = open(io -> CompGraph(io, insizes...; vfun), filename)
+NaiveNASlib.CompGraph(io::IO, insizes...; vfun = create_vertex_default) = CompGraph(extract(io), insizes...; vfun)
+NaiveNASlib.CompGraph(m::ONNX.ModelProto, insizes...; vfun = create_vertex_default) = CompGraph(m.graph, insizes...; vfun)
+NaiveNASlib.CompGraph(g::ONNX.GraphProto, insizes...; vfun = create_vertex_default) = CompGraph(CompGraphBuilder(g, insizes...); vfun)
+function NaiveNASlib.CompGraph(gb::CompGraphBuilder; vfun = create_vertex_default)
+   outputs::Vector{AbstractVertex} = vertex.(gb, node.(name.(gb.g.output), gb), vfun)
    fix_zerosizes!.(outputs, gb)
    graph = CompGraph(gb.inputs, outputs)
    return graph

--- a/src/serialize/serialize.jl
+++ b/src/serialize/serialize.jl
@@ -170,7 +170,7 @@ Argument `outshape` is a function which returns the shape of an `AbstractVertex`
 
 Argument `namestrat` determines how nodes shall be named.
 """
-graphproto(g::CompGraph, outshape = shape, namestrat=default_namestrat(g)) = graphproto(g, (recursename.(g.inputs, namestrat) .=> shape.(g.inputs))...;namestrat=namestrat)
+graphproto(g::CompGraph, outshape = shape, namestrat=default_namestrat(g)) = graphproto(g, (recursename.(g.inputs, namestrat) .=> outshape.(g.inputs))...;namestrat=namestrat)
 
 """
     graphproto(f, indata::Pair{String, <:Any}...; namestrat = name_runningnr())

--- a/src/serialize/serialize.jl
+++ b/src/serialize/serialize.jl
@@ -135,10 +135,7 @@ newnamestrat(p::ProtoProbe, f, pname=p.name) = ProtoProbe(pname, p.shape, f, p.g
 Return a new `ProtoProbe` with name `outname`. Argument `fshape` is used to determine a new shape (typically a function).
 """
 newfrom(p::ProtoProbe, outname::AbstractString, fshape) = ProtoProbe(outname, nextshape(p, fshape), p.nextname, p.graph)
-
-nextshape(p::AbstractProbe, f::Function) = nextshape(shape(p), f)
-nextshape(::Missing, f::Function) = missing # We want missing to propagate, even if possible to infer output shape? Not necessary for anything though so it should be possible to change if needed.
-nextshape(s::Tuple, f::Function) = f(s)
+nextshape(p::AbstractProbe, f::Function) = f(shape(p))
 
 add!(gp::ONNX.GraphProto, np::ONNX.NodeProto) = push!(gp.node, np)
 
@@ -375,7 +372,7 @@ globalmeanpool(pp::AbstractProbe, wrap) = globalpool(pp, wrap, "GlobalAveragePoo
 globalmaxpool(pp::AbstractProbe, wrap) = globalpool(pp, wrap, "GlobalMaxPool")
 
 function globalpool(pp::AbstractProbe, wrap, type)
-     gpp = attribfun(s -> (1, 1, s[3:end]...), type, pp)
+     gpp = attribfun(s -> ismissing(s) ? s : (1, 1, s[3:end]...), type, pp)
      ppnext = newnamestrat(gpp, f -> join([gpp.name, genname(f)], "_"), gpp.name)
      wpp = wrap(ppnext)
      return newnamestrat(wpp, nextname(gpp))

--- a/src/serialize/serialize.jl
+++ b/src/serialize/serialize.jl
@@ -456,7 +456,9 @@ function axisfun(fshape, optype, pps::AbstractProbe...; dims, axname="axes")
     attrib = if isempty(dims)
         ONNX.AttributeProto[]
     else
-        np_axis = flux2numpydim.(dims, ndims(pps[1]))
+        pok = filter(p -> !ismissing(shape(p)), pps)
+        @assert !isempty(pok) "Must have at least one shape to determine axis!"
+        np_axis = flux2numpydim.(dims, ndims(pok[1]))
         [ONNX.AttributeProto(axname, np_axis)]
     end
 

--- a/src/shapes.jl
+++ b/src/shapes.jl
@@ -58,8 +58,22 @@ end
 
 outshape(l, s) = outshape(layertype(l), l, s)
 
-outshape(lt::FluxDense, l, s) = (nout(l), s[end])
-function outshape(lt::FluxConvolutional{N}, l, s) where N
+function outshape(::FluxDense, l, s) 
+    assertshape(s, 2, l)
+    assertsize(s[1], nin(l), l)
+    return (nout(l), s[end])
+end
+function outshape(::FluxRecurrent, l, s)
+    assertshape(s, (3, 4), l)
+    assertsize(s[1], nin(l), l)
+    # ONNX wants num directions as an extra dimension to output
+    # Fluxs RNNs are not bidirectional so num directions is always 1
+    return (nout(l), s[2], 1, s[end])
+end
+
+function outshape(::FluxConvolutional{N}, l, s) where N
+    assertshape(s, N+2, l)
+    assertsize(s[N+1], nin(l), l)
     p = length(l.pad) == N ? 2 .* l.pad : l.pad[1:2:end] .+ l.pad[2:2:end]
     k = size(weights(l))[1:N]
     d = l.dilation
@@ -69,11 +83,11 @@ function outshape(lt::FluxConvolutional{N}, l, s) where N
         # Conv arithmetic from https://arxiv.org/pdf/1603.07285.pdf
         aggshape(x -> (x + p[i] - k[i] - (k[i] - 1)*(d[i] - 1)) ÷ stride[i] + 1, si)
     end
-
-    return (o..., nout(l), s[end])
+    return (o..., nout(l), s[N+2])
 end
 
-function outsize(l::Union{Flux.MaxPool{N}, Flux.MeanPool{N}}, s) where N
+function outshape(l::Union{Flux.MaxPool{N}, Flux.MeanPool{N}}, s) where N
+    assertshape(s, N+2, l)
     p = length(l.pad) == N ? 2 .* l.pad : l.pad[1:2:end] .+ l.pad[2:2:end]
     k = l.k
     stride = l.stride
@@ -83,5 +97,17 @@ function outsize(l::Union{Flux.MaxPool{N}, Flux.MeanPool{N}}, s) where N
         aggshape(x -> (x + p[i] - k[i]) ÷ stride[i] + 1, si)
     end
 
-    return (o..., nout(l), s[end])
+    return (o..., s[N+1], s[N+2])
 end
+
+function assertshape(s, expected, lmsg)
+    if all(!=(length(s)), expected)
+        throw(DimensionMismatch("Wrong input dimension for $(lmsg)! Expected $(join(expected,", ", " or ")) dimensions, got shape $s"))
+    end
+end
+function assertsize(s::Integer, expected, lmsg)
+    if s != expected
+        throw(DimensionMismatch("Wrong input size for $(lmsg)! Expected $expected elements, got size $s"))
+    end
+end
+function assertsize(s, expected, lmsg) end

--- a/test/serialize/serialize.jl
+++ b/test/serialize/serialize.jl
@@ -526,7 +526,7 @@
             NaiveNASflux.layer(c::CntSpy) = layer(c.f)
             NaiveNASflux.layertype(c::CntSpy) = layertype(c.f)
 
-            g_new = CompGraph(gt_new, (args...) -> create_vertex_default(args...;layerfun=CntSpy))
+            g_new = CompGraph(gt_new; vfun = (args...) -> create_vertex_default(args...;layerfun=CntSpy))
 
             indata = reshape(collect(Float32, 1:3*4), nout(v0), :)
             outdata = ones(Float32, nout(v3), size(indata, 2))
@@ -568,7 +568,7 @@
             NaiveNASflux.layer(c::CntSpy) = layer(c.f)
             NaiveNASflux.layertype(c::CntSpy) = layertype(c.f)
 
-            g_new = CompGraph(gt_new, (args...) -> create_vertex_default(args...;layerfun=CntSpy))
+            g_new = CompGraph(gt_new; vfun = (args...) -> create_vertex_default(args...;layerfun=CntSpy))
 
             indata = reshape(collect(Float32, 1:3*4), nout(v0), :)
             outdata = ones(Float32, nout(v4), size(indata, 2))

--- a/test/serialize/serialize.jl
+++ b/test/serialize/serialize.jl
@@ -14,7 +14,7 @@
         return ONNXmutable.extract(iob)
     end
 
-    cfun(::ONNX.NodeProto) = np -> OnnxNode(np, TensorProto[])
+    cfun(::ONNX.NodeProto) = np -> OnnxNode(np, ONNX.TensorProto[])
     cfun(::ONNX.TensorProto) = array
     cfun(::ONNX.GraphProto) = identity
 
@@ -25,18 +25,20 @@
         import ONNXmutable: optype, actfuns, fluxlayers, invariantops
         using NaiveNASflux
         import NaiveNASflux: weights, bias
-        import ONNXmutable: AbstractProbe, nextname, newfrom, add!, genname
-        struct NodeProbe{F} <: AbstractProbe
+        import ONNXmutable: AbstractProbe, nextname, newfrom, add!, genname, shape, nextshape
+        struct NodeProbe{F, S} <: AbstractProbe
             name::String
             namefun::F
+            shape::S
             protos::Vector{Any}
         end
-        NodeProbe(name, namefun) = NodeProbe(name, namefun, [])
+        NodeProbe(name, namefun, shape=missing) = NodeProbe(name, namefun, shape, [])
         ONNXmutable.add!(p::NodeProbe, n) = push!(p.protos, n)
         ONNXmutable.nextname(p::NodeProbe) = p.namefun
-        ONNXmutable.newfrom(p::NodeProbe, pname, Δshape=nothing) = NodeProbe(pname, p.namefun, p.protos)
-        ONNXmutable.newnamestrat(p::NodeProbe, f, pname = name(p)) = NodeProbe(pname, f, p.protos)
+        ONNXmutable.newfrom(p::NodeProbe, pname, Δshape=identity) = NodeProbe(pname, p.namefun, nextshape(p, Δshape), p.protos)
+        ONNXmutable.newnamestrat(p::NodeProbe, f, pname = name(p)) = NodeProbe(pname, f, p.shape, p.protos)
         ONNXmutable.name(p::NodeProbe) = p.name
+        ONNXmutable.shape(p::NodeProbe) = p.shape
 
         @testset "Paramfree op $(tc.op) attrs: $(pairs(tc.attr))" for tc in (
             (op=:Relu, attr = Dict(), fd=actfuns),
@@ -78,8 +80,7 @@
             (f=mean, dims=(2, 3), ndims=4, ot=:ReduceMean, axname=:axes),
             (f=dropdims, dims=(3,), ndims=3, ot=:Squeeze, axname=:axes)
             )
-            inprobe = NodeProbe("input", f -> "output")
-            ONNXmutable.shape(p::NodeProbe) = Tuple(1:tc.ndims)
+            inprobe = NodeProbe("input", f -> "output", Tuple(1:tc.ndims))
 
             outprobe = tc.f(inprobe, dims=tc.dims)
 
@@ -96,15 +97,10 @@
         end
 
         @testset "Reshape" begin
-            inprobe = NodeProbe("input", f -> "output")
-
-            shapeout = 1
-            function ONNXmutable.newfrom(p::NodeProbe, pname, Δshape::Function)
-                shapeout = Δshape((:A, missing, 12))
-                return NodeProbe(pname, p.namefun, p.protos)
-             end
+            inprobe = NodeProbe("input", f -> "output", (:A, missing, 12))
 
             outprobe = reshape(inprobe, (0, 3, 2, Colon()))
+            shapeout = shape(outprobe)
 
             @test length(outprobe.protos) == 2
 
@@ -137,9 +133,8 @@
             (layer=Conv((1,2), 3=>4, relu; pad=(2,1), stride=(1,2), dilation=3), indata=reshape(collect(Float32, 1:2*3*9*9), 9,9,3,2) .- 5),
             (layer=Conv((2,3), 3=>4, relu; pad=(1,2,3,4), stride=(1,2), dilation=3), indata=reshape(collect(Float32, 1:2*3*9*9), 9,9,3,2) .- 10),
             )
-            ONNXmutable.shape(p::NodeProbe) = missing
 
-            inprobe = NodeProbe("input", genname)
+            inprobe = NodeProbe("input", genname, shape(layertype(tc.layer), nin(tc.layer)))
 
             outprobe = tc.layer(inprobe)
 
@@ -178,9 +173,8 @@
             (layer=Dense(randn(Float32, 2,3), Flux.Zeros()), indata=reshape(collect(Float32, 1:12), :, 4) .- 3),
             (layer=Conv((1,1), 2=>3; bias=Flux.Zeros(3)), indata=reshape(collect(Float32, 1:2*3), 1,1,2,3) .- 3),
             )
-            ONNXmutable.shape(p::NodeProbe) = missing
 
-            inprobe = NodeProbe("input", genname)
+            inprobe = NodeProbe("input", genname, shape(layertype(tc.layer), nin(tc.layer)))
 
             outprobe = tc.layer(inprobe)
 
@@ -213,8 +207,7 @@
             )
             import NaiveNASflux: hiddenweights
 
-            ONNXmutable.shape(p::NodeProbe) = (missing, nout(tc.layer), missing)
-            inprobe = NodeProbe("input", genname)
+            inprobe = NodeProbe("input", genname, shape(layertype(tc.layer), nin(tc.layer)))
 
             outprobe = tc.layer(inprobe)
 
@@ -805,6 +798,59 @@
 
             indata = reshape(collect(Float32, 1:1*2*3*4), 1,2,3,4)
             @test g_org(indata) ≈ g_new(indata)
+        end
+    end
+
+    @testset "Allowed input shapes" begin
+        function remodel(m, args...; assertwarn=true)
+            pb = PipeBuffer()
+            onnx(pb, m, args...)
+            # TODO: It seems like this warning might be possible to avoid 
+            if assertwarn && (isempty(args) || any(ismissing, args))
+                return @test_logs (:warn, r"Mismatched") CompGraph(pb)
+            end
+            return CompGraph(pb)
+        end
+
+        @testset "Allowed input shapes op: $(tc[1])" for tc in (
+            (Dense(2, 3), ((2, 3), (2, missing), missing, (missing, missing)), (2, 2)),
+            (Conv((1,1), 2=>3), ((1,1,2,1), (1, missing, missing, missing), missing, ntuple(i -> missing, 4)), (1,1,2,1)),
+        )     
+            op, testsizes, validsize = tc
+            inpt = ones(Float32, validsize)
+
+            g1 = remodel(op)
+            @test g1(inpt) == op(inpt)
+            @testset "Inputshape $s" for s in testsizes
+                g = remodel(op, s)
+                @test g(inpt) == op(inpt)
+            end
+        end
+
+        @testset "Allowed input shapes op: +" begin
+            in1, in2 = ones(3), ones(3)
+            op = (x,y) -> x .+ y
+            g1 = remodel(op; assertwarn=false)
+            @test g1(in1, in2) == in1 .+ in2
+            @testset "Inputshape $s1, $s2" for (s1, s2) in (
+                ((2,), (2,)),
+                )
+                g = remodel(op, s1, s2; assertwarn=false)
+                @test g(in1, in2) == in1 .+ in2
+            end
+        end
+        
+        @testset "Disallowed input shapes op: $(tc[1])" for tc in (
+            (Dense(2,3), ((2,), (3, 1), (missing, ), (1,2,3,4))),
+            (Conv((1,), 2=>3), ((2,), (missing, ), (1,1,1), (2,3,4,5,6), (2,3,4,5))),
+            (Conv((1,1), 2=>3), ((2,), (missing, ), (1,1,1,1), (2,3,4,5,6), (2,3,4))),
+            (MaxPool((2,2)), ((2,), (missing, ), (1,1,1), (2,3,4,5,6))),
+            (RNN(2,3), ((2, ), (missing,), (2,1), (1,2,3), (2,3,4,5,6)))
+        )
+            op, testsizes = tc
+            @testset "Inputshape $s" for s in testsizes
+                @test_throws DimensionMismatch remodel(op, s)
+            end
         end
     end
 end

--- a/test/serialize/serialize.jl
+++ b/test/serialize/serialize.jl
@@ -814,7 +814,9 @@
 
         @testset "Allowed input shapes op: $(tc[1])" for tc in (
             (Dense(2, 3), ((2, 3), (2, missing), missing, (missing, missing)), (2, 2)),
+            (Conv((1,), 2=>3), ((1,2,1), (1, missing, missing), missing, ntuple(i -> missing, 3)), (1,2,1)),
             (Conv((1,1), 2=>3), ((1,1,2,1), (1, missing, missing, missing), missing, ntuple(i -> missing, 4)), (1,1,2,1)),
+            (RNN(2,3), ((2,3,1), missing, ntuple(i -> missing, 3), ntuple(i -> missing ,4)), (2, 3))
         )     
             op, testsizes, validsize = tc
             inpt = ones(Float32, validsize)
@@ -823,6 +825,7 @@
             @test g1(inpt) == op(inpt)
             @testset "Inputshape $s" for s in testsizes
                 g = remodel(op, s)
+                Flux.reset!(op) # For RNNs or else the test below will fail
                 @test g(inpt) == op(inpt)
             end
         end
@@ -833,7 +836,9 @@
             g1 = remodel(op; assertwarn=false)
             @test g1(in1, in2) == in1 .+ in2
             @testset "Inputshape $s1, $s2" for (s1, s2) in (
-                ((2,), (2,)),
+                ((3,), (3,)),
+                ((missing,), (missing,)),
+                (missing, missing),
                 )
                 g = remodel(op, s1, s2; assertwarn=false)
                 @test g(in1, in2) == in1 .+ in2


### PR DESCRIPTION
Fixes #29 

Now also includes the option to override input shapes when loading a model. I found this to be useful when exploring a bit more what happens when the ONNX input shape is missing or when the activation dimension is either missing or specified as a variable.