### PR TITLE
Serialize missing input shape using missing TensorShapeProto

### DIFF
--- a/src/baseonnx/read.jl
+++ b/src/baseonnx/read.jl
@@ -48,7 +48,7 @@ end
 Base.size(vip::ValueInfoProto) = size(vip._type)
 Base.size(tp::TypeProto) = size(tp.tensor_type)
 Base.size(tp::TensorProto) = tp.dims
-Base.size(tp_t::TypeProto_Tensor) = size(tp_t.shape)
+Base.size(tp_t::TypeProto_Tensor) = hasproperty(tp_t, :shape) ? size(tp_t.shape) : missing
 Base.size(tsp::TensorShapeProto) = size.(Tuple(reverse(tsp.dim)))
 Base.size(tsp_d::TensorShapeProto_Dimension) = hasproperty(tsp_d, :dim_value) ? tsp_d.dim_value : missing
 

--- a/src/baseonnx/write.jl
+++ b/src/baseonnx/write.jl
@@ -4,14 +4,19 @@ ValueInfoProto(name::String, inshape, elemtype=Float32) =
 ValueInfoProto(
     name=name,
     _type=TypeProto(
-        tensor_type=TypeProto_Tensor(
-            elem_type=tp_tensor_elemtype(elemtype),
-            shape=TensorShapeProto(inshape)
-        )
+        tensor_type=TypeProto_Tensor(inshape, elemtype)
     )
 )
+
+TypeProto_Tensor(inshape, elemtype) = TypeProto_Tensor(
+    elem_type=tp_tensor_elemtype(elemtype),
+    shape=TensorShapeProto(inshape)
+)
+TypeProto_Tensor(::Missing, elemtype) = TypeProto_Tensor(
+    elem_type=tp_tensor_elemtype(elemtype)
+)
+
 TensorShapeProto(shape) = TensorShapeProto(dim=[tsp_d(s) for s in reverse(shape)])
-TensorShapeProto(::Missing) = TensorShapeProto()
 tsp_d(::Missing) = TensorShapeProto_Dimension()
 tsp_d(n::Integer) = TensorShapeProto_Dimension(dim_value=n)
 tsp_d(s::String) = TensorShapeProto_Dimension(dim_param=s)

--- a/src/deserialize/graphbuilder.jl
+++ b/src/deserialize/graphbuilder.jl
@@ -44,10 +44,11 @@ end
 sizes(mp::ONNX.ModelProto) = sizes(mp.graph)
 sizes(gp::ONNX.GraphProto) = Dict((name.(gp.input) .=> size.(gp.input))..., (name.(gp.output) .=> size.(gp.output))...)
 
-clean_size(d::AbstractDict) = Dict(k => clean_size(v) for (k,v) in pairs(d))
-clean_size(t::Tuple) = clean_size.(t)
-clean_size(i::Integer) = i
-clean_size(::Any) = 0
+clean_size(d::AbstractDict) = Dict(k => clean_size(v) for (k,v) in d)
+clean_size(t::Tuple) = int_size.(t)
+clean_size(::Missing) = tuple()
+int_size(i::Integer) = i
+int_size(::Any) = 0
 
 function output_to_node(nodes, initdict)
    allnodes = Dict{String, OnnxNode}()
@@ -111,7 +112,7 @@ function select_layertype(inname, inshape, lts::Tuple)
    ltsvalid = filter(lts) do lt
       length(inshape) == 0 || length(inshape) == length(shape(lt, 0))
    end |> unique
-
+   
    length(ltsvalid) == 1 && return ltsvalid[1]
    length(ltsvalid) == 0 && return guess_layertype(length(inshape))
    @warn "Multiple layertypes found for input $inname with shape $inshape: $(ltsvalid)! Graph mutation near this vertex might fail!"

--- a/test/deserialize/deserialize.jl
+++ b/test/deserialize/deserialize.jl
@@ -275,7 +275,7 @@ end
         return pb
     end
 
-    insize(t::Tuple) = ONNXmutable.clean_size(t[NaiveNASflux.actdim(length(t))])
+    insize(t::Tuple) = ONNXmutable.int_size(t[NaiveNASflux.actdim(length(t))])
     insize(p::Pair) = p |> last |> insize
     @testset "Input format $inshapes" for inshapes in (
         ((4,1), (4,1)),


### PR DESCRIPTION
Fixes #42 

I think this is the right way. Relevant section of spec:

The use of the string "*" (as a dimension variable) to denote a sequence of zero or more dimensions of unknown cardinality. This is not supported. In the current implementation, the number of dimensions in a shape MUST represent the rank of the tensor. **A tensor of unknown rank is represented using a TypeProto::Tensor object with no shape, which is legal**.